### PR TITLE
Fix require paths for publish/subscribe example

### DIFF
--- a/src/publish-subscribe/publish.cr
+++ b/src/publish-subscribe/publish.cr
@@ -1,5 +1,5 @@
 
-require "../../src/redis"
+require "redis"
 
 redis = Redis.new
 puts "Connected to Redis"

--- a/src/publish-subscribe/subscribe.cr
+++ b/src/publish-subscribe/subscribe.cr
@@ -1,4 +1,4 @@
-require "../../src/redis"
+require "redis"
 
 redis = Redis.new
 puts "Connected to Redis - subscribing to mychannel and waiting for messages from publish.cr"


### PR DESCRIPTION
The paths in the publish/subscribe example were to nonexistent file. Pointing it to lib fixes that.
