### PR TITLE
Add psubscribe example

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.3.0
 dependencies:
   redis:
     git: https://github.com/stefanwille/crystal-redis.git
-    version: ~> 1.7.1
+    version: ~> 1.9.0
 
 
 license: BSD

--- a/src/publish-subscribe/README.md
+++ b/src/publish-subscribe/README.md
@@ -3,13 +3,17 @@
 First start one or more subscribers:
 
 ```bash
-$ crystal run examples/publish-subscribe/subscribe.cr
+$ crystal run src/publish-subscribe/subscribe.cr
+```
+
+```bash
+$ crystal run src/publish-subscribe/psubscribe.cr
 ```
 
 Then start one or more publishers in separate terminal windows:
 
 ```bash
-$ crystal run examples/publish-subscribe/publish.cr
+$ crystal run src/publish-subscribe/publish.cr
 ```
 
 Now when you type a message in the prompt of one of the publishers, it will

--- a/src/publish-subscribe/psubscribe.cr
+++ b/src/publish-subscribe/psubscribe.cr
@@ -1,0 +1,8 @@
+require "redis"
+
+redis = Redis.new
+redis.psubscribe("mychan*") do |on|
+  on.pmessage do |channel_pattern, channel, message|
+    puts "Received #{message} from #{channel} while listening to #{channel_pattern}"
+  end
+end

--- a/src/publish-subscribe/subscribe.cr
+++ b/src/publish-subscribe/subscribe.cr
@@ -3,6 +3,6 @@ require "redis"
 redis = Redis.new
 redis.subscribe("mychannel") do |on|
   on.message do |channel, message|
-    redis.ping
+    puts "Received #{message} from #{channel}"
   end
 end


### PR DESCRIPTION
- Add psubscribe example
- Update to crystal-redis 1.9
- Switch to a puts statement instead of `redis.ping`, as it causes a crash
- Document running psubscribe example